### PR TITLE
Let user specify root for Pytorch datasets

### DIFF
--- a/gdeep/data/datasets/build_datasets.py
+++ b/gdeep/data/datasets/build_datasets.py
@@ -23,8 +23,10 @@ class TorchvisionDatasetBuilder(object):
         self.dataset_name = dataset_name
 
     def __call__(self, **kwargs):  # type: ignore
+        if 'root' not in kwargs:
+            kwargs = dict(root=DEFAULT_DOWNLOAD_DIR, **kwargs)
         return datasets.__getattribute__(self.dataset_name)(  # type: ignore
-            root=DEFAULT_DOWNLOAD_DIR, **kwargs  # type: ignore
+            **kwargs  # type: ignore
         )
 
 
@@ -36,8 +38,10 @@ class TorchtextDatasetBuilder(object):
         self.dataset_name = dataset_name
 
     def __call__(self, **kwargs):  # type: ignore
+        if 'root' not in kwargs:
+            kwargs = dict(root=DEFAULT_DOWNLOAD_DIR, **kwargs)
         return textdatasets.__getattribute__(self.dataset_name)(  # type: ignore
-            root=DEFAULT_DOWNLOAD_DIR, **kwargs  # type: ignore
+            **kwargs  # type: ignore
         )
 
 


### PR DESCRIPTION
**Reference issues/PRs**
Fixes #126 

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Description**
A "root" argument containing a default path is only added to the dictionnary of kwargs propagated to Pytorch's datasets if the user provided none

**Any other comments?**
The corresponding issue referred only to the torchvision datasets but the problem also affected the torchtext datasets.This PR fixes both

**Checklist**
- [x] I have read the [guidelines for contributing](https://giotto-ai.github.io/gtda-docs/latest/contributing/#guidelines).
- [x] My code follows the code style of this project. I used `flake8` to check my Python changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. I used `pytest` to check this on Python tests.
